### PR TITLE
Update to Muzei API 3.4, fixing actions on Android 10+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-   ext.kotlin_version = '1.3.61'
+   ext.kotlin_version = '1.3.72'
    repositories {
       google()
       jcenter()
    }
    dependencies {
-      classpath 'com.android.tools.build:gradle:3.5.3'
+      classpath 'com.android.tools.build:gradle:4.0.1'
       classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
    }
 }

--- a/muzei-nationalgeographic/build.gradle
+++ b/muzei-nationalgeographic/build.gradle
@@ -23,7 +23,7 @@ dependencies {
    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
    implementation 'androidx.core:core-ktx:1.1.0'
    // muzei
-   implementation 'com.google.android.apps.muzei:muzei-api:3.2.0'
+   implementation 'com.google.android.apps.muzei:muzei-api:3.4.0'
    // retrofit
    implementation 'com.squareup.retrofit2:retrofit:2.6.2'
    implementation 'com.squareup.retrofit2:converter-gson:2.5.0'
@@ -34,13 +34,12 @@ dependencies {
 }
 
 android {
-   compileSdkVersion 29
+   compileSdkVersion 30
 
    defaultConfig {
       applicationId 'de.msal.muzei.nationalgeographic'
       minSdkVersion 21
       targetSdkVersion 29
-      buildToolsVersion '28.0.3'
       // SemVer
       def major = 2
       def minor = 2

--- a/muzei-nationalgeographic/src/main/kotlin/de/msal/muzei/nationalgeographic/NationalGeographicArtProvider.kt
+++ b/muzei-nationalgeographic/src/main/kotlin/de/msal/muzei/nationalgeographic/NationalGeographicArtProvider.kt
@@ -1,8 +1,12 @@
 package de.msal.muzei.nationalgeographic
 
+import android.app.PendingIntent
+import android.content.Context
 import android.content.Intent
+import androidx.annotation.StringRes
+import androidx.core.app.RemoteActionCompat
+import androidx.core.graphics.drawable.IconCompat
 import androidx.preference.PreferenceManager
-import com.google.android.apps.muzei.api.UserCommand
 import com.google.android.apps.muzei.api.provider.Artwork
 import com.google.android.apps.muzei.api.provider.MuzeiArtProvider
 
@@ -19,41 +23,85 @@ class NationalGeographicArtProvider : MuzeiArtProvider() {
       NationalGeographicWorker.enqueueLoad(isRandom, shouldShowLegacy)
    }
 
-   override fun getCommands(artwork: Artwork) = listOf(
-         UserCommand(USER_COMMAND_ID_PHOTO_DESCRIPTION, context?.getString(R.string.photo_desc_open)),
-         UserCommand(USER_COMMAND_ID_SHARE, context?.getString(R.string.share_artwork_title)))
+   /* This is the new API for Muzei 3.4+ that works on all API levels */
+   override fun getCommandActions(artwork: Artwork): List<RemoteActionCompat> {
+      val context = context ?: return super.getCommandActions(artwork)
+      return listOf(
+              createRemoteActionCompat(context, artwork,
+                      ::createPhotoDescriptionIntent, R.string.photo_desc_open),
+              createRemoteActionCompat(context, artwork,
+                      ::createShareIntent, R.string.share_artwork_title))
+   }
 
-   /*
-    * Not working properly in Android 10. See:
-    * - https://github.com/romannurik/muzei/issues/644
-    * - https://developer.android.com/guide/components/activities/background-starts
-    */
+   /* kept for backward compatibility with Muzei 3.3 */
+   @Suppress("OverridingDeprecatedMember", "DEPRECATION")
+   override fun getCommands(artwork: Artwork) = listOf(
+           com.google.android.apps.muzei.api.UserCommand(USER_COMMAND_ID_PHOTO_DESCRIPTION,
+                   context?.getString(R.string.photo_desc_open)),
+           com.google.android.apps.muzei.api.UserCommand(USER_COMMAND_ID_SHARE,
+                   context?.getString(R.string.share_artwork_title)))
+
+   /* kept for backward compatibility with Muzei 3.3 */
+   @Suppress("OverridingDeprecatedMember")
    override fun onCommand(artwork: Artwork, id: Int) {
       val context = context ?: return
       when (id) {
          USER_COMMAND_ID_PHOTO_DESCRIPTION -> {
-            Intent(context, PhotoDescriptionActivity::class.java).apply {
-               putExtra(PhotoDescriptionActivity.EXTRA_TITLE, artwork. title)
-               putExtra(PhotoDescriptionActivity.EXTRA_DESC, artwork.token)
-               flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            createPhotoDescriptionIntent(context, artwork).apply {
+               addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             }.takeIf { it.resolveActivity(context.packageManager) != null }?.run {
                context.startActivity(this)
             }
          }
          USER_COMMAND_ID_SHARE -> {
-            Intent.createChooser(Intent(Intent.ACTION_SEND).apply {
-               type = "text/plain"
-               putExtra(Intent.EXTRA_TEXT, context.getString(R.string.share_artwork_message,
-                     artwork.title,
-                     artwork.byline,
-                     artwork.webUri))
-            }, context.getString(R.string.share_artwork_title))?.apply {
+            createShareIntent(context, artwork).apply {
                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            }?.takeIf { it.resolveActivity(context.packageManager) != null }?.run {
+            }.takeIf { it.resolveActivity(context.packageManager) != null }?.run {
                context.startActivity(this)
             }
          }
       }
+   }
+
+   private fun createPhotoDescriptionIntent(
+           context: Context,
+           artwork: Artwork
+   ) = Intent(context, PhotoDescriptionActivity::class.java).apply {
+      putExtra(PhotoDescriptionActivity.EXTRA_TITLE, artwork. title)
+      putExtra(PhotoDescriptionActivity.EXTRA_DESC, artwork.token)
+   }
+
+   private fun createShareIntent(
+           context: Context,
+           artwork: Artwork
+   ): Intent = Intent.createChooser(Intent(Intent.ACTION_SEND).apply {
+      type = "text/plain"
+      putExtra(Intent.EXTRA_TEXT, context.getString(R.string.share_artwork_message,
+              artwork.title,
+              artwork.byline,
+              artwork.webUri))
+   }, context.getString(R.string.share_artwork_title))
+
+   /**
+    * Construct a new [RemoteActionCompat] instance. Here, we use
+    * [RemoteActionCompat.setShouldShowIcon] with `false` to continue to show
+    * the icon in the overflow menu.
+    *
+    * If you wanted the icon to appear as an icon, that line should be removed
+    * and a custom icon should be added in place of `R.drawable.muzei_launch_command`.
+    */
+   private fun createRemoteActionCompat(
+           context: Context,
+           artwork: Artwork,
+           intentProvider: (context: Context, artwork: Artwork) -> Intent,
+           @StringRes titleRes: Int
+   ) = RemoteActionCompat(
+           IconCompat.createWithResource(context, R.drawable.muzei_launch_command),
+           context.getString(titleRes),
+           context.getString(titleRes),
+           PendingIntent.getActivity(context, artwork.id.toInt(),
+                   intentProvider.invoke(context, artwork), 0)).apply {
+      setShouldShowIcon(false)
    }
 
 }

--- a/muzei-nationalgeographic/src/main/kotlin/de/msal/muzei/nationalgeographic/NationalGeographicWorker.kt
+++ b/muzei-nationalgeographic/src/main/kotlin/de/msal/muzei/nationalgeographic/NationalGeographicWorker.kt
@@ -60,15 +60,14 @@ class NationalGeographicWorker(context: Context, workerParams: WorkerParameters)
       }
 
       // success -> set Artwork
-      val artwork = Artwork().apply {
-         title = photo.image.title
-         byline = photo.publishDate
-         attribution = photo.image.credit
-         persistentUri = photo.image.renditions.last().uri.toUri()
-         token = photo.image.caption ?: photo.image.renditions.last().uri
-         webUri = photo.pageUrl?.toUri()
-      }
-      val providerClient = ProviderContract.getProviderClient(applicationContext, NationalGeographicArtProvider::class.java)
+      val artwork = Artwork(
+         title = photo.image.title,
+         byline = photo.publishDate,
+         attribution = photo.image.credit,
+         persistentUri = photo.image.renditions.last().uri.toUri(),
+         token = photo.image.caption ?: photo.image.renditions.last().uri,
+         webUri = photo.pageUrl?.toUri())
+      val providerClient = ProviderContract.getProviderClient<NationalGeographicArtProvider>(applicationContext)
       if (isRandom) {
          providerClient.addArtwork(artwork)
       } else {


### PR DESCRIPTION
Use the new `getCommandActions()` API to fix the 'About this photo' and 'Share this photo' actions on Android 10+ devices. By keeping the old APIs as well, we maintain backward compatibility with Muzei 3.3 users (although the actions still won't work for those users who are running Android 10+ - they'll still need to upgrade to Muzei 3.4).

The `NationalGeographicWorker` was changed to be compatible with the Kotlin rewrite of the Muzei API and use the reified version of `getProviderClient()` to avoid the `::class.java` stuff that was previously required.

Muzei API 3.4 requires Kotlin 1.3.72 and a `compileSdkVersion` of 30 (which then required we upgrade the Android Gradle Plugin to 4.0.1), so those were also updated.